### PR TITLE
Ct mongodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 [![License](https://img.shields.io/badge/license-MIT%20License-brightgreen.svg)](./LICENSE)
 # Ansible Collection - almaops.common
 
@@ -25,36 +26,29 @@ collections:
 
 ## Roles
 
-### almaops.common.pkg
-
-Packages installation. Please consult with role's [README](./roles/pkg/README.md)
-
-### almaops.common.pip
-
-Python pip packages installation. Please consult with role's [README](./roles/pip/README.md)
-
-### almaops.common.docker
-
-Installation/configuration for Docker daemon and Docker client userspace configuration. Please consult with role's [README](./roles/pip/README.md)
-
 ### almaops.common.cron
-
 Configuration of cron jobs. Please consult with role's [README](./roles/cron/README.md)
 
-### almaops.common.flush_handlers
+### almaops.common.ct_mongodb
+Deployment a MongoDB container based on the official docker image (https://hub.docker.com/_/mongo). Please consult with role's [README](./roles/ct_mongodb/README.md)
 
+### almaops.common.docker
+Installation/configuration for Docker daemon and Docker client userspace configuration. Please consult with role's [README](./roles/pip/README.md)
+
+### almaops.common.flush_handlers
 Flushing Ansible handlers between other roles. Please consult with role's [README](./roles/flush_handlers/README.md)
 
-### almaops.common.systemd
+### almaops.common.pip
+Python pip packages installation. Please consult with role's [README](./roles/pip/README.md)
 
+### almaops.common.pkg
+Packages installation. Please consult with role's [README](./roles/pkg/README.md)
+
+### almaops.common.systemd
 Manipulating systemd services between other roles. Please consult with role's [README](./roles/systemd/README.md)
 
 ### almaops.common.template
-
 Templating from file or in-place. Please consult with role's [README](./roles/template/README.md)
 
 ### almaops.common.timezone
-
 Setup host's time zone. Please consult with role's [README](./roles/timezone/README.md)
-
-

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ collections:
 Configuration of cron jobs. Please consult with role's [README](./roles/cron/README.md)
 
 ### almaops.common.ct_mongodb
-Deployment a MongoDB container based on the official docker image (https://hub.docker.com/_/mongo). Please consult with role's [README](./roles/ct_mongodb/README.md)
+Role deploys a MongoDB container from Docker Hub image. Please consult with role's [README](./roles/ct_mongodb/README.md)
 
 ### almaops.common.docker
 Installation/configuration for Docker daemon and Docker client userspace configuration. Please consult with role's [README](./roles/pip/README.md)

--- a/roles/ct_mongodb/LICENSE
+++ b/roles/ct_mongodb/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2022 Aleksandr Vzhesnevskiy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/roles/ct_mongodb/README.md
+++ b/roles/ct_mongodb/README.md
@@ -1,5 +1,5 @@
 
-# almaops.ct_mongodb
+# almaops.common.ct_mongodb
 [![License](https://img.shields.io/badge/license-MIT%20License-brightgreen.svg)](https://opensource.org/licenses/MIT)
 
 # Requirements
@@ -14,12 +14,12 @@ None
 # Example playbook
 ```
 - name: Deployment of the MongoDB
-  hosts: ct_mongodb
+  hosts: almaops.common.ct_mongodb
   become: yes
   vars_files:
     - "{{ playbook_dir }}/.../.yml" 
   roles:
-    - role: "ct_mongodb"
+    - role: "almaops.common.ct_mongodb"
 ```
 
 # License

--- a/roles/ct_mongodb/README.md
+++ b/roles/ct_mongodb/README.md
@@ -12,6 +12,7 @@ Please refer to [defaults/main.yml](./defaults/main.yml) for full list of availa
 None
 
 # Example playbook
+
 ```
 - name: Deployment of the MongoDB
   hosts: almaops.common.ct_mongodb

--- a/roles/ct_mongodb/README.md
+++ b/roles/ct_mongodb/README.md
@@ -1,0 +1,29 @@
+
+# almaops.ct_mongodb
+[![License](https://img.shields.io/badge/license-MIT%20License-brightgreen.svg)](https://opensource.org/licenses/MIT)
+
+# Requirements
+Docker and docker-py must be installed on target host.
+
+# Role variables
+Please refer to [defaults/main.yml](./defaults/main.yml) for full list of available variables. 
+
+# Dependencies
+None
+
+# Example playbook
+```
+- name: Deployment of the MongoDB
+  hosts: ct_mongodb
+  become: yes
+  vars_files:
+    - "{{ playbook_dir }}/.../.yml" 
+  roles:
+    - role: "ct_mongodb"
+```
+
+# License
+[MIT](./LICENSE)
+
+# Contributors
+[Aleksandr Vzhesnevskiy](https://github.com/hDw1z)

--- a/roles/ct_mongodb/README.md
+++ b/roles/ct_mongodb/README.md
@@ -12,10 +12,7 @@ Please refer to [defaults/main.yml](./defaults/main.yml) for full list of availa
 None
 
 # Example playbook
-<<<<<<< HEAD
 
-=======
->>>>>>> origin/master
 ```
 - name: Deployment of the MongoDB
   hosts: almaops.common.ct_mongodb

--- a/roles/ct_mongodb/defaults/main.yml
+++ b/roles/ct_mongodb/defaults/main.yml
@@ -1,0 +1,32 @@
+
+# ct_mongodb
+
+
+
+# General settings
+ct_mongodb_task_prefix: "=== CT_MONGODB ==="
+
+# Path settings
+ct_mongodb_out_path_config: "/srv/{{ ct_mongodb_name }}"
+
+# Container settings
+ct_mongodb_image: "mongo"
+# ct_mongodb_version: "..."
+# Note: The name of the MongoDB container should be exactly like this. Otherwise the deployment will fail.
+ct_mongodb_name: "mongodb"
+ct_mongodb_volumes: "{{ ct_mongodb_out_path_config }}/data/db:/data/db"
+ct_mongodb_env:
+  MONGODB_INITDB_ROOT_USERNAME: "root"
+  MONGODB_INITDB_ROOT_PASSWORD: "{{ secret_ct_mongodb_env_MONGO_INITDB_ROOT_PASSWORD }}"
+  MONGODB_ADVERTISED_HOSTNAME: "{{ ct_mongodb_name }}"
+  MONGODB_PORT_NUMBER: "27017"
+  MONGODB_REPLICA_SET_MODE: "primary"
+  MONGODB_REPLICA_SET_NAME: "rs0"
+  MONGODB_INITIAL_PRIMARY_HOST: "{{ ct_mongodb_name }}"
+  MONGODB_INITIAL_PRIMARY_PORT_NUMBER: "27017"
+  MONGODB_ENABLE_JOURNAL: "true"
+  # The value of "ALLOW_EMPTY_PASSWORD" should be exactly "yes". Otherwise the deployment will fail.
+  ALLOW_EMPTY_PASSWORD: "yes"
+ct_mongodb_ports: "27017:27017"
+ct_mongodb_restart: "false"
+ct_mongodb_restart_policy: "unless-stopped"

--- a/roles/ct_mongodb/defaults/main.yml
+++ b/roles/ct_mongodb/defaults/main.yml
@@ -1,36 +1,44 @@
-
-# ct_mongodb
-
-
-
+---
 # General settings
 ct_mongodb_task_prefix: "=== CT_MONGODB ==="
 
-# Path settings
-ct_mongodb_out_path_config: "/srv/{{ ct_mongodb_ct_name }}"
+# Templates
+ct_mongodb_template_env: "mongodb.env.j2"
 
-# Container settings
-ct_mongodb_ct_image: "bitnami/mongodb"
-# ct_mongodb_ct_version: "..."
-# Note: The name of the MongoDB container should be exactly like this. Otherwise the deployment will fail.
+# Path settings - Configuration file
+ct_mongodb_path_config_base: "/etc/ct_mongodb"
+ct_mongodb_path_config_file: "{{ ct_mongodb_path_config_base }}/{{ ct_mongodb_ct_name }}.env"
+# Path settings - Data directory
+ct_mongodb_path_data_base: "/srv/ct_mongodb"
+ct_mongodb_path_data_volume: "{{ ct_mongodb_path_data_base }}/{{ ct_mongodb_ct_name }}"
+ct_mongodb_path_ct_data: "/data/db"
+
+# Network settings
+ct_mongodb_bind_addr: "127.0.0.1"
+ct_mongodb_bind_port: "27017"
+ct_mongodb_bind_ct_port: "27017"
+
+# Container settings - general
 ct_mongodb_ct_name: "mongodb"
-ct_mongodb_ct_volumes: "{{ ct_mongodb_out_path_config }}:/bitnami/mongodb"
-ct_mongodb_ct_env:
-  MONGODB_INITDB_ROOT_USERNAME: "root"
-  MONGODB_INITDB_ROOT_PASSWORD: "{{ secret_ct_mongodb_ct_env_MONGO_INITDB_ROOT_PASSWORD }}"
-  MONGODB_ADVERTISED_HOSTNAME: "{{ ct_mongodb_ct_name }}"
-  MONGODB_PORT_NUMBER: "27017"
-  MONGODB_REPLICA_SET_MODE: "primary"
-  MONGODB_REPLICA_SET_NAME: "rs0"
-  MONGODB_INITIAL_PRIMARY_HOST: "{{ ct_mongodb_ct_name }}"
-  MONGODB_INITIAL_PRIMARY_PORT_NUMBER: "27017"
-  MONGODB_ENABLE_JOURNAL: "true"
-  # The value of "ALLOW_EMPTY_PASSWORD" should be exactly "yes". Otherwise the deployment will fail.
-  ALLOW_EMPTY_PASSWORD: "yes"
-# ct_mongodb_ct_bind_addr: "127.0.0.1"
-ct_mongodb_ct_bind_port: "27017"
-ct_mongodb_ct_ports: "{{ ct_mongodb_ct_bind_addr }}:{{ ct_mongodb_ct_bind_port }}:27017"
-ct_mongodb_ct_restart: "false"
-ct_mongodb_ct_restart_policy: "unless-stopped"
-# Network if necessary.
-# ct_mongodb_network: "..."
+ct_mongodb_ct_version: "latest"
+ct_mongodb_ct_image: "mongo:{{ ct_mongodb_ct_version }}"
+ct_mongodb_ct_state: "started"
+ct_mongodb_ct_restart_policy: "always"
+ct_mongodb_ct_restart: false
+ct_mongodb_ct_pull: false
+ct_mongodb_ct_recreate: false
+ct_mongodb_ct_network_mode: "default"
+ct_mongodb_ct_networks: []
+ct_mongodb_ct_ports:
+  - "{{ ct_mongodb_bind_addr }}:{{ ct_mongodb_bind_port }}:{{ ct_mongodb_bind_ct_port }}"
+ct_mongodb_ct_ports_extra: []
+ct_mongodb_ct_volume_extra: []
+ct_mongodb_ct_volume_data:
+  - "{{ ct_mongodb_path_data_volume }}:{{ ct_mongodb_path_ct_data }}"
+ct_mongodb_ct_volumes: "{{ ct_mongodb_ct_volume_data + ct_mongodb_ct_volume_extra }}"
+
+# Environment variables
+# ct_mongodb_env_mongodb_initdb_root_username: "root"
+# ct_mongodb_env_mongodb_initdb_root_password: "changeme"
+ct_mongodb_env_extra: {}
+...

--- a/roles/ct_mongodb/defaults/main.yml
+++ b/roles/ct_mongodb/defaults/main.yml
@@ -7,26 +7,28 @@
 ct_mongodb_task_prefix: "=== CT_MONGODB ==="
 
 # Path settings
-ct_mongodb_out_path_config: "/srv/{{ ct_mongodb_name }}"
+ct_mongodb_out_path_config: "/srv/{{ ct_mongodb_ct_name }}"
 
 # Container settings
-ct_mongodb_image: "mongo"
-# ct_mongodb_version: "..."
+ct_mongodb_ct_image: "mongo"
+# ct_mongodb_ct_version: "..."
 # Note: The name of the MongoDB container should be exactly like this. Otherwise the deployment will fail.
-ct_mongodb_name: "mongodb"
-ct_mongodb_volumes: "{{ ct_mongodb_out_path_config }}/data/db:/data/db"
-ct_mongodb_env:
+ct_mongodb_ct_name: "mongodb"
+ct_mongodb_ct_volumes: "{{ ct_mongodb_out_path_config }}/data/db:/data/db"
+ct_mongodb_ct_env:
   MONGODB_INITDB_ROOT_USERNAME: "root"
-  MONGODB_INITDB_ROOT_PASSWORD: "{{ secret_ct_mongodb_env_MONGO_INITDB_ROOT_PASSWORD }}"
-  MONGODB_ADVERTISED_HOSTNAME: "{{ ct_mongodb_name }}"
+  MONGODB_INITDB_ROOT_PASSWORD: "{{ secret_ct_mongodb_ct_env_MONGO_INITDB_ROOT_PASSWORD }}"
+  MONGODB_ADVERTISED_HOSTNAME: "{{ ct_mongodb_ct_name }}"
   MONGODB_PORT_NUMBER: "27017"
   MONGODB_REPLICA_SET_MODE: "primary"
   MONGODB_REPLICA_SET_NAME: "rs0"
-  MONGODB_INITIAL_PRIMARY_HOST: "{{ ct_mongodb_name }}"
+  MONGODB_INITIAL_PRIMARY_HOST: "{{ ct_mongodb_ct_name }}"
   MONGODB_INITIAL_PRIMARY_PORT_NUMBER: "27017"
   MONGODB_ENABLE_JOURNAL: "true"
   # The value of "ALLOW_EMPTY_PASSWORD" should be exactly "yes". Otherwise the deployment will fail.
   ALLOW_EMPTY_PASSWORD: "yes"
-ct_mongodb_ports: "27017:27017"
-ct_mongodb_restart: "false"
-ct_mongodb_restart_policy: "unless-stopped"
+# ct_mongodb_ct_bind_addr: "127.0.0.1"
+ct_mongodb_ct_bind_port: "27017"
+ct_mongodb_ct_ports: "{{ ct_mongodb_ct_bind_addr }}:{{ ct_mongodb_ct_bind_port }}:27017"
+ct_mongodb_ct_restart: "false"
+ct_mongodb_ct_restart_policy: "unless-stopped"

--- a/roles/ct_mongodb/defaults/main.yml
+++ b/roles/ct_mongodb/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General settings
-ct_mongodb_task_prefix: "=== CT_MONGODB ==="
+ct_mongodb_task_prefix: "=== CT_mongodb ==="
 
 # Templates
 ct_mongodb_template_env: "mongodb.env.j2"
@@ -8,10 +8,13 @@ ct_mongodb_template_env: "mongodb.env.j2"
 # Path settings - Configuration file
 ct_mongodb_path_config_base: "/etc/ct_mongodb"
 ct_mongodb_path_config_file: "{{ ct_mongodb_path_config_base }}/{{ ct_mongodb_ct_name }}.env"
+
 # Path settings - Data directory
 ct_mongodb_path_data_base: "/srv/ct_mongodb"
 ct_mongodb_path_data_volume: "{{ ct_mongodb_path_data_base }}/{{ ct_mongodb_ct_name }}"
-ct_mongodb_path_ct_data: "/data/db"
+#ct_mongodb_path_data_volume_owner: "1001"
+#ct_mongodb_path_ct_data_dbms_dir: "/bitnami/mongodb"
+ct_mongodb_path_ct_data: "{{ ct_mongodb_path_ct_data_dbms_dir }}"
 
 # Network settings
 ct_mongodb_bind_addr: "127.0.0.1"
@@ -19,26 +22,28 @@ ct_mongodb_bind_port: "27017"
 ct_mongodb_bind_ct_port: "27017"
 
 # Container settings - general
+# ct_mongodb_ct_version: "latest"
+#ct_mongodb_ct_image: "bitnami/mongodb:{{ ct_mongodb_ct_version }}"
 ct_mongodb_ct_name: "mongodb"
-ct_mongodb_ct_version: "latest"
-ct_mongodb_ct_image: "mongo:{{ ct_mongodb_ct_version }}"
-ct_mongodb_ct_state: "started"
-ct_mongodb_ct_restart_policy: "always"
-ct_mongodb_ct_restart: false
-ct_mongodb_ct_pull: false
-ct_mongodb_ct_recreate: false
-ct_mongodb_ct_network_mode: "default"
-ct_mongodb_ct_networks: []
+ct_mongodb_ct_volume_data:
+  - "{{ ct_mongodb_path_data_volume }}:{{ ct_mongodb_path_ct_data }}"
+ct_mongodb_ct_volume_extra: []
+ct_mongodb_ct_volumes: "{{ ct_mongodb_ct_volume_data + ct_mongodb_ct_volume_extra }}"
 ct_mongodb_ct_ports:
   - "{{ ct_mongodb_bind_addr }}:{{ ct_mongodb_bind_port }}:{{ ct_mongodb_bind_ct_port }}"
 ct_mongodb_ct_ports_extra: []
-ct_mongodb_ct_volume_extra: []
-ct_mongodb_ct_volume_data:
-  - "{{ ct_mongodb_path_data_volume }}:{{ ct_mongodb_path_ct_data }}"
-ct_mongodb_ct_volumes: "{{ ct_mongodb_ct_volume_data + ct_mongodb_ct_volume_extra }}"
+ct_mongodb_ct_pull: "false"
+ct_mongodb_ct_recreate: "false"
+ct_mongodb_ct_restart_policy: "always"
+ct_mongodb_ct_restart: "false"
+ct_mongodb_ct_state: "started"
+ct_mongodb_ct_network_mode: "default"
+ct_mongodb_ct_networks: []
 
 # Environment variables
 # ct_mongodb_env_mongodb_initdb_root_username: "root"
 # ct_mongodb_env_mongodb_initdb_root_password: "changeme"
+ct_mongodb_env_mongodb_port_number: "{{ ct_mongodb_bind_ct_port }}"
+ct_mongodb_env_mongodb_enable_journal: "true"
 ct_mongodb_env_extra: {}
 ...

--- a/roles/ct_mongodb/defaults/main.yml
+++ b/roles/ct_mongodb/defaults/main.yml
@@ -1,10 +1,6 @@
 ---
 # General settings
-<<<<<<< HEAD
-ct_mongodb_task_prefix: "=== CT_mongodb ==="
-=======
 ct_mongodb_task_prefix: "=== CT_MONGODB ==="
->>>>>>> origin/master
 
 # Templates
 ct_mongodb_template_env: "mongodb.env.j2"
@@ -12,7 +8,6 @@ ct_mongodb_template_env: "mongodb.env.j2"
 # Path settings - Configuration file
 ct_mongodb_path_config_base: "/etc/ct_mongodb"
 ct_mongodb_path_config_file: "{{ ct_mongodb_path_config_base }}/{{ ct_mongodb_ct_name }}.env"
-<<<<<<< HEAD
 
 # Path settings - Data directory
 ct_mongodb_path_data_base: "/srv/ct_mongodb"
@@ -20,12 +15,6 @@ ct_mongodb_path_data_volume: "{{ ct_mongodb_path_data_base }}/{{ ct_mongodb_ct_n
 #ct_mongodb_path_data_volume_owner: "1001"
 #ct_mongodb_path_ct_data_dbms_dir: "/bitnami/mongodb"
 ct_mongodb_path_ct_data: "{{ ct_mongodb_path_ct_data_dbms_dir }}"
-=======
-# Path settings - Data directory
-ct_mongodb_path_data_base: "/srv/ct_mongodb"
-ct_mongodb_path_data_volume: "{{ ct_mongodb_path_data_base }}/{{ ct_mongodb_ct_name }}"
-ct_mongodb_path_ct_data: "/data/db"
->>>>>>> origin/master
 
 # Network settings
 ct_mongodb_bind_addr: "127.0.0.1"
@@ -33,7 +22,6 @@ ct_mongodb_bind_port: "27017"
 ct_mongodb_bind_ct_port: "27017"
 
 # Container settings - general
-<<<<<<< HEAD
 # ct_mongodb_ct_version: "latest"
 #ct_mongodb_ct_image: "bitnami/mongodb:{{ ct_mongodb_ct_version }}"
 ct_mongodb_ct_name: "mongodb"
@@ -51,33 +39,11 @@ ct_mongodb_ct_restart: "false"
 ct_mongodb_ct_state: "started"
 ct_mongodb_ct_network_mode: "default"
 ct_mongodb_ct_networks: []
-=======
-ct_mongodb_ct_name: "mongodb"
-ct_mongodb_ct_version: "latest"
-ct_mongodb_ct_image: "mongo:{{ ct_mongodb_ct_version }}"
-ct_mongodb_ct_state: "started"
-ct_mongodb_ct_restart_policy: "always"
-ct_mongodb_ct_restart: false
-ct_mongodb_ct_pull: false
-ct_mongodb_ct_recreate: false
-ct_mongodb_ct_network_mode: "default"
-ct_mongodb_ct_networks: []
-ct_mongodb_ct_ports:
-  - "{{ ct_mongodb_bind_addr }}:{{ ct_mongodb_bind_port }}:{{ ct_mongodb_bind_ct_port }}"
-ct_mongodb_ct_ports_extra: []
-ct_mongodb_ct_volume_extra: []
-ct_mongodb_ct_volume_data:
-  - "{{ ct_mongodb_path_data_volume }}:{{ ct_mongodb_path_ct_data }}"
-ct_mongodb_ct_volumes: "{{ ct_mongodb_ct_volume_data + ct_mongodb_ct_volume_extra }}"
->>>>>>> origin/master
 
 # Environment variables
 # ct_mongodb_env_mongodb_initdb_root_username: "root"
 # ct_mongodb_env_mongodb_initdb_root_password: "changeme"
-<<<<<<< HEAD
 ct_mongodb_env_mongodb_port_number: "{{ ct_mongodb_bind_ct_port }}"
 ct_mongodb_env_mongodb_enable_journal: "true"
-=======
->>>>>>> origin/master
 ct_mongodb_env_extra: {}
 ...

--- a/roles/ct_mongodb/defaults/main.yml
+++ b/roles/ct_mongodb/defaults/main.yml
@@ -12,8 +12,8 @@ ct_mongodb_path_config_file: "{{ ct_mongodb_path_config_base }}/{{ ct_mongodb_ct
 # Path settings - Data directory
 ct_mongodb_path_data_base: "/srv/ct_mongodb"
 ct_mongodb_path_data_volume: "{{ ct_mongodb_path_data_base }}/{{ ct_mongodb_ct_name }}"
-#ct_mongodb_path_data_volume_owner: "1001"
-#ct_mongodb_path_ct_data_dbms_dir: "/bitnami/mongodb"
+# ct_mongodb_path_data_volume_owner: "1001"
+# ct_mongodb_path_ct_data_dbms_dir: "/bitnami/mongodb"
 ct_mongodb_path_ct_data: "{{ ct_mongodb_path_ct_data_dbms_dir }}"
 
 # Network settings
@@ -23,7 +23,7 @@ ct_mongodb_bind_ct_port: "27017"
 
 # Container settings - general
 # ct_mongodb_ct_version: "latest"
-#ct_mongodb_ct_image: "bitnami/mongodb:{{ ct_mongodb_ct_version }}"
+# ct_mongodb_ct_image: "bitnami/mongodb:{{ ct_mongodb_ct_version }}"
 ct_mongodb_ct_name: "mongodb"
 ct_mongodb_ct_volume_data:
   - "{{ ct_mongodb_path_data_volume }}:{{ ct_mongodb_path_ct_data }}"

--- a/roles/ct_mongodb/defaults/main.yml
+++ b/roles/ct_mongodb/defaults/main.yml
@@ -10,11 +10,11 @@ ct_mongodb_task_prefix: "=== CT_MONGODB ==="
 ct_mongodb_out_path_config: "/srv/{{ ct_mongodb_ct_name }}"
 
 # Container settings
-ct_mongodb_ct_image: "mongo"
+ct_mongodb_ct_image: "bitnami/mongodb"
 # ct_mongodb_ct_version: "..."
 # Note: The name of the MongoDB container should be exactly like this. Otherwise the deployment will fail.
 ct_mongodb_ct_name: "mongodb"
-ct_mongodb_ct_volumes: "{{ ct_mongodb_out_path_config }}/data/db:/data/db"
+ct_mongodb_ct_volumes: "{{ ct_mongodb_out_path_config }}:/bitnami/mongodb"
 ct_mongodb_ct_env:
   MONGODB_INITDB_ROOT_USERNAME: "root"
   MONGODB_INITDB_ROOT_PASSWORD: "{{ secret_ct_mongodb_ct_env_MONGO_INITDB_ROOT_PASSWORD }}"
@@ -32,3 +32,5 @@ ct_mongodb_ct_bind_port: "27017"
 ct_mongodb_ct_ports: "{{ ct_mongodb_ct_bind_addr }}:{{ ct_mongodb_ct_bind_port }}:27017"
 ct_mongodb_ct_restart: "false"
 ct_mongodb_ct_restart_policy: "unless-stopped"
+# Network if necessary.
+# ct_mongodb_network: "..."

--- a/roles/ct_mongodb/meta/main.yml
+++ b/roles/ct_mongodb/meta/main.yml
@@ -1,8 +1,4 @@
-
-# ct_mongodb
-
-
-
+---
 galaxy_info:
   author: Aleksandr Vzhesnevskiy
   role_name: ct_mongodb
@@ -16,3 +12,4 @@ galaxy_info:
   galaxy_tags:
     - mongo
 dependencies: []
+...

--- a/roles/ct_mongodb/meta/main.yml
+++ b/roles/ct_mongodb/meta/main.yml
@@ -1,0 +1,18 @@
+
+# ct_mongodb
+
+
+
+galaxy_info:
+  author: Aleksandr Vzhesnevskiy
+  role_name: ct_mongodb
+  description: The role was created based on the "mongo" docker image from https://hub.docker.com
+  license: MIT
+  min_ansible_version: "2.12"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+  galaxy_tags:
+    - mongo
+dependencies: []

--- a/roles/ct_mongodb/meta/main.yml
+++ b/roles/ct_mongodb/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: Aleksandr Vzhesnevskiy
   role_name: ct_mongodb
-  description: The role was created based on the "mongo" docker image from https://hub.docker.com
+  description: Role deploys a MongoDB container from Docker Hub image
   license: MIT
   min_ansible_version: "2.12"
   platforms:
@@ -10,6 +10,6 @@ galaxy_info:
       versions:
         - jammy
   galaxy_tags:
-    - mongo
+    - mongodb
 dependencies: []
 ...

--- a/roles/ct_mongodb/meta/main.yml
+++ b/roles/ct_mongodb/meta/main.yml
@@ -2,11 +2,7 @@
 galaxy_info:
   author: Aleksandr Vzhesnevskiy
   role_name: ct_mongodb
-<<<<<<< HEAD
   description: Role deploys a MongoDB container from Docker Hub image
-=======
-  description: The role was created based on the "mongo" docker image from https://hub.docker.com
->>>>>>> origin/master
   license: MIT
   min_ansible_version: "2.12"
   platforms:
@@ -14,10 +10,6 @@ galaxy_info:
       versions:
         - jammy
   galaxy_tags:
-<<<<<<< HEAD
     - mongodb
-=======
-    - mongo
->>>>>>> origin/master
 dependencies: []
 ...

--- a/roles/ct_mongodb/tasks/main.yml
+++ b/roles/ct_mongodb/tasks/main.yml
@@ -3,13 +3,13 @@
 
 
 
-- name: "{{ ct_mongodb_task_prefix }}. Creating a '{{ ct_mongodb_name }}' container"
+- name: "{{ ct_mongodb_task_prefix }}. Creating a '{{ ct_mongodb_ct_name }}' container"
   docker_container:
-    image: "{{ ct_mongodb_image }}:{{ ct_mongodb_version }}"
-    name: "{{ ct_mongodb_name }}"
-    volumes: "{{ ct_mongodb_volumes }}"
-    env: "{{ ct_mongodb_env }}"
-    ports: "{{ ct_mongodb_ports }}"
-    restart: "{{ ct_mongodb_restart | bool }}"
-    restart_policy: "{{ ct_mongodb_restart_policy }}"
+    image: "{{ ct_mongodb_ct_image }}:{{ ct_mongodb_ct_version }}"
+    name: "{{ ct_mongodb_ct_name }}"
+    volumes: "{{ ct_mongodb_ct_volumes }}"
+    env: "{{ ct_mongodb_ct_env }}"
+    ports: "{{ ct_mongodb_ct_ports }}"
+    restart: "{{ ct_mongodb_ct_restart | bool }}"
+    restart_policy: "{{ ct_mongodb_ct_restart_policy }}"
     state: "started"

--- a/roles/ct_mongodb/tasks/main.yml
+++ b/roles/ct_mongodb/tasks/main.yml
@@ -13,3 +13,9 @@
     restart: "{{ ct_mongodb_ct_restart | bool }}"
     restart_policy: "{{ ct_mongodb_ct_restart_policy }}"
     state: "started"
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongo {{ ct_mongodb_ct_bind_addr }}:{{ ct_mongodb_ct_bind_port }}/test --quiet
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 60s

--- a/roles/ct_mongodb/tasks/main.yml
+++ b/roles/ct_mongodb/tasks/main.yml
@@ -2,36 +2,22 @@
 - name: "{{ ct_mongodb_task_prefix }} Create config directory"
   ansible.builtin.file:
     path: "{{ ct_mongodb_path_config_base }}"
-<<<<<<< HEAD
     state: "directory"
     owner: "root"
     group: "root"
     mode: "0700"
-=======
-    state: directory
-    mode: '0700'
-    owner: root
-    group: root
->>>>>>> origin/master
 
 - name: "{{ ct_mongodb_task_prefix }} Create env file"
   ansible.builtin.template:
     src: "{{ ct_mongodb_template_env }}"
     dest: "{{ ct_mongodb_path_config_file }}"
-<<<<<<< HEAD
     owner: "root"
     group: "root"
     mode: "0400"
-=======
-    owner: root
-    group: root
-    mode: '0400'
->>>>>>> origin/master
 
 - name: "{{ ct_mongodb_task_prefix }} Create data directory"
   ansible.builtin.file:
     path: "{{ ct_mongodb_path_data_volume }}"
-<<<<<<< HEAD
     state: "directory"
     owner: "{{ ct_mongodb_path_data_volume_owner }}"
     group: "root"
@@ -44,28 +30,11 @@
     name: "{{ ct_mongodb_ct_name }}"
     volumes: "{{ ct_mongodb_ct_volumes }}"
     env_file: "{{ ct_mongodb_path_config_file }}"
-=======
-    state: directory
-    mode: '0700'
-    owner: root
-    group: root
-
-- name: "{{ ct_mongodb_task_prefix }} Provision container"
-  community.docker.docker_container:
-    env_file: "{{ ct_mongodb_path_config_file }}"
-    image: "{{ ct_mongodb_ct_image }}"
-    name: "{{ ct_mongodb_ct_name }}"
->>>>>>> origin/master
     ports: "{{ ct_mongodb_ct_ports }}"
     pull: "{{ ct_mongodb_ct_pull }}"
     recreate: "{{ ct_mongodb_ct_recreate }}"
     restart_policy: "{{ ct_mongodb_ct_restart_policy }}"
-<<<<<<< HEAD
     restart: "{{ ct_mongodb_ct_restart }}"
     state: "{{ ct_mongodb_ct_state }}"
-=======
-    state: "{{ ct_mongodb_ct_state }}"
-    volumes: "{{ ct_mongodb_ct_volumes }}"
->>>>>>> origin/master
     network_mode: "{{ ct_mongodb_ct_network_mode }}"
 ...

--- a/roles/ct_mongodb/tasks/main.yml
+++ b/roles/ct_mongodb/tasks/main.yml
@@ -1,0 +1,15 @@
+
+# ct_mongodb
+
+
+
+- name: "{{ ct_mongodb_task_prefix }}. Creating a '{{ ct_mongodb_name }}' container"
+  docker_container:
+    image: "{{ ct_mongodb_image }}:{{ ct_mongodb_version }}"
+    name: "{{ ct_mongodb_name }}"
+    volumes: "{{ ct_mongodb_volumes }}"
+    env: "{{ ct_mongodb_env }}"
+    ports: "{{ ct_mongodb_ports }}"
+    restart: "{{ ct_mongodb_restart | bool }}"
+    restart_policy: "{{ ct_mongodb_restart_policy }}"
+    state: "started"

--- a/roles/ct_mongodb/tasks/main.yml
+++ b/roles/ct_mongodb/tasks/main.yml
@@ -3,6 +3,15 @@
 
 
 
+- name: "{{ ct_mongodb_task_prefix }}. Creating the '{{ ct_mongodb_out_path_config }}' directory"
+  file:
+    path: "{{ ct_mongodb_out_path_config }}"
+    state: directory
+    owner: 1001
+    recurse: true
+
+
+
 - name: "{{ ct_mongodb_task_prefix }}. Creating a '{{ ct_mongodb_ct_name }}' container"
   docker_container:
     image: "{{ ct_mongodb_ct_image }}:{{ ct_mongodb_ct_version }}"
@@ -13,6 +22,8 @@
     restart: "{{ ct_mongodb_ct_restart | bool }}"
     restart_policy: "{{ ct_mongodb_ct_restart_policy }}"
     state: "started"
+    networks:
+      - name: "{{ ct_mongodb_network }}"
     healthcheck:
       test: echo 'db.runCommand("ping").ok' | mongo {{ ct_mongodb_ct_bind_addr }}:{{ ct_mongodb_ct_bind_port }}/test --quiet
       interval: 10s

--- a/roles/ct_mongodb/tasks/main.yml
+++ b/roles/ct_mongodb/tasks/main.yml
@@ -2,37 +2,39 @@
 - name: "{{ ct_mongodb_task_prefix }} Create config directory"
   ansible.builtin.file:
     path: "{{ ct_mongodb_path_config_base }}"
-    state: directory
-    mode: '0700'
-    owner: root
-    group: root
+    state: "directory"
+    owner: "root"
+    group: "root"
+    mode: "0700"
 
 - name: "{{ ct_mongodb_task_prefix }} Create env file"
   ansible.builtin.template:
     src: "{{ ct_mongodb_template_env }}"
     dest: "{{ ct_mongodb_path_config_file }}"
-    owner: root
-    group: root
-    mode: '0400'
+    owner: "root"
+    group: "root"
+    mode: "0400"
 
 - name: "{{ ct_mongodb_task_prefix }} Create data directory"
   ansible.builtin.file:
     path: "{{ ct_mongodb_path_data_volume }}"
-    state: directory
-    mode: '0700'
-    owner: root
-    group: root
+    state: "directory"
+    owner: "{{ ct_mongodb_path_data_volume_owner }}"
+    group: "root"
+    mode: "0700"
+    recurse: "true"
 
 - name: "{{ ct_mongodb_task_prefix }} Provision container"
   community.docker.docker_container:
-    env_file: "{{ ct_mongodb_path_config_file }}"
     image: "{{ ct_mongodb_ct_image }}"
     name: "{{ ct_mongodb_ct_name }}"
+    volumes: "{{ ct_mongodb_ct_volumes }}"
+    env_file: "{{ ct_mongodb_path_config_file }}"
     ports: "{{ ct_mongodb_ct_ports }}"
     pull: "{{ ct_mongodb_ct_pull }}"
     recreate: "{{ ct_mongodb_ct_recreate }}"
     restart_policy: "{{ ct_mongodb_ct_restart_policy }}"
+    restart: "{{ ct_mongodb_ct_restart }}"
     state: "{{ ct_mongodb_ct_state }}"
-    volumes: "{{ ct_mongodb_ct_volumes }}"
     network_mode: "{{ ct_mongodb_ct_network_mode }}"
 ...

--- a/roles/ct_mongodb/tasks/main.yml
+++ b/roles/ct_mongodb/tasks/main.yml
@@ -1,32 +1,38 @@
-
-# ct_mongodb
-
-
-
-- name: "{{ ct_mongodb_task_prefix }}. Creating the '{{ ct_mongodb_out_path_config }}' directory"
-  file:
-    path: "{{ ct_mongodb_out_path_config }}"
+---
+- name: "{{ ct_mongodb_task_prefix }} Create config directory"
+  ansible.builtin.file:
+    path: "{{ ct_mongodb_path_config_base }}"
     state: directory
-    owner: 1001
-    recurse: true
+    mode: '0700'
+    owner: root
+    group: root
 
+- name: "{{ ct_mongodb_task_prefix }} Create env file"
+  ansible.builtin.template:
+    src: "{{ ct_mongodb_template_env }}"
+    dest: "{{ ct_mongodb_path_config_file }}"
+    owner: root
+    group: root
+    mode: '0400'
 
+- name: "{{ ct_mongodb_task_prefix }} Create data directory"
+  ansible.builtin.file:
+    path: "{{ ct_mongodb_path_data_volume }}"
+    state: directory
+    mode: '0700'
+    owner: root
+    group: root
 
-- name: "{{ ct_mongodb_task_prefix }}. Creating a '{{ ct_mongodb_ct_name }}' container"
-  docker_container:
-    image: "{{ ct_mongodb_ct_image }}:{{ ct_mongodb_ct_version }}"
+- name: "{{ ct_mongodb_task_prefix }} Provision container"
+  community.docker.docker_container:
+    env_file: "{{ ct_mongodb_path_config_file }}"
+    image: "{{ ct_mongodb_ct_image }}"
     name: "{{ ct_mongodb_ct_name }}"
-    volumes: "{{ ct_mongodb_ct_volumes }}"
-    env: "{{ ct_mongodb_ct_env }}"
     ports: "{{ ct_mongodb_ct_ports }}"
-    restart: "{{ ct_mongodb_ct_restart | bool }}"
+    pull: "{{ ct_mongodb_ct_pull }}"
+    recreate: "{{ ct_mongodb_ct_recreate }}"
     restart_policy: "{{ ct_mongodb_ct_restart_policy }}"
-    state: "started"
-    networks:
-      - name: "{{ ct_mongodb_network }}"
-    healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongo {{ ct_mongodb_ct_bind_addr }}:{{ ct_mongodb_ct_bind_port }}/test --quiet
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 60s
+    state: "{{ ct_mongodb_ct_state }}"
+    volumes: "{{ ct_mongodb_ct_volumes }}"
+    network_mode: "{{ ct_mongodb_ct_network_mode }}"
+...

--- a/roles/ct_mongodb/templates/mongodb.env.j2
+++ b/roles/ct_mongodb/templates/mongodb.env.j2
@@ -1,0 +1,5 @@
+MONGODB_INITDB_ROOT_USERNAME={{ ct_mongodb_env_mongodb_initdb_root_username }}
+MONGODB_INITDB_ROOT_PASSWORD={{ ct_mongodb_env_mongodb_initdb_root_password }}
+{% for key, value in ct_mongodb_env_extra.items() %}
+{{ key }}={{ value }}
+{% endfor %}

--- a/roles/ct_mongodb/templates/mongodb.env.j2
+++ b/roles/ct_mongodb/templates/mongodb.env.j2
@@ -1,6 +1,5 @@
 MONGODB_INITDB_ROOT_USERNAME={{ ct_mongodb_env_mongodb_initdb_root_username }}
 MONGODB_INITDB_ROOT_PASSWORD={{ ct_mongodb_env_mongodb_initdb_root_password }}
-<<<<<<< HEAD
 MONGODB_PORT_NUMBER={{ ct_mongodb_env_mongodb_port_number }}
 MONGODB_ENABLE_JOURNAL={{ ct_mongodb_env_mongodb_enable_journal }}
 {% if ct_mongodb_path_ct_data_dbms_dir == '/bitnami/mongodb' %}
@@ -11,8 +10,6 @@ MONGODB_INITIAL_PRIMARY_HOST={{ ct_mongodb_env_mongodb_initial_primary_host }}
 MONGODB_INITIAL_PRIMARY_PORT_NUMBER={{ ct_mongodb_env_mongodb_initial_primary_port_number }}
 ALLOW_EMPTY_PASSWORD={{ ct_mongodb_env_allow_empty_password }}
 {% endif %}
-=======
->>>>>>> origin/master
 {% for key, value in ct_mongodb_env_extra.items() %}
 {{ key }}={{ value }}
 {% endfor %}

--- a/roles/ct_mongodb/templates/mongodb.env.j2
+++ b/roles/ct_mongodb/templates/mongodb.env.j2
@@ -1,5 +1,15 @@
 MONGODB_INITDB_ROOT_USERNAME={{ ct_mongodb_env_mongodb_initdb_root_username }}
 MONGODB_INITDB_ROOT_PASSWORD={{ ct_mongodb_env_mongodb_initdb_root_password }}
+MONGODB_PORT_NUMBER={{ ct_mongodb_env_mongodb_port_number }}
+MONGODB_ENABLE_JOURNAL={{ ct_mongodb_env_mongodb_enable_journal }}
+{% if ct_mongodb_path_ct_data_dbms_dir == '/bitnami/mongodb' %}
+MONGODB_ADVERTISED_HOSTNAME={{ ct_mongodb_env_mongodb_advertised_hostname }}
+MONGODB_REPLICA_SET_MODE={{ ct_mongodb_env_mongodb_replica_set_mode }}
+MONGODB_REPLICA_SET_NAME={{ ct_mongodb_env_mongodb_replica_set_name }}
+MONGODB_INITIAL_PRIMARY_HOST={{ ct_mongodb_env_mongodb_initial_primary_host }}
+MONGODB_INITIAL_PRIMARY_PORT_NUMBER={{ ct_mongodb_env_mongodb_initial_primary_port_number }}
+ALLOW_EMPTY_PASSWORD={{ ct_mongodb_env_allow_empty_password }}
+{% endif %}
 {% for key, value in ct_mongodb_env_extra.items() %}
 {{ key }}={{ value }}
 {% endfor %}


### PR DESCRIPTION
Внёс изменения в роль ct_mongodb для её унификации (возможности использовать, как [официальный](https://hub.docker.com/_/mongo) докер-образ MongoDB, так и не официальный, например https://hub.docker.com/r/bitnami/mongodb).